### PR TITLE
Add overloads to extension methods that return a single object to allow filtering based on a supplied predicate

### DIFF
--- a/src/AutoMapper.EF6/EntityFrameworkExtensions.cs
+++ b/src/AutoMapper.EF6/EntityFrameworkExtensions.cs
@@ -1,8 +1,10 @@
 ﻿namespace AutoMapper
 {
+    using System;
     using System.Collections.Generic;
     using System.Data.Entity;
     using System.Linq;
+    using System.Linq.Expressions;
     using System.Threading.Tasks;
     using QueryableExtensions;
     using DelegateDecompiler;
@@ -35,9 +37,19 @@
             return await queryable.ProjectTo<TDestination>(config).DecompileAsync().SingleOrDefaultAsync();
         }
 
+        public static async Task<TDestination> ProjectToSingleOrDefaultAsync<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate, IConfigurationProvider config)
+        {
+            return await queryable.Where(predicate).ProjectTo<TDestination>(config).DecompileAsync().SingleOrDefaultAsync();
+        }
+
         public static async Task<TDestination> ProjectToSingleOrDefaultAsync<TDestination>(this IQueryable queryable)
         {
             return await queryable.ProjectTo<TDestination>().DecompileAsync().SingleOrDefaultAsync();
+        }
+
+        public static async Task<TDestination> ProjectToSingleOrDefaultAsync<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
+        {
+            return await queryable.Where(predicate).ProjectTo<TDestination>().DecompileAsync().SingleOrDefaultAsync();
         }
 
         public static async Task<TDestination> ProjectToSingleAsync<TDestination>(this IQueryable queryable, IConfigurationProvider config)
@@ -45,9 +57,19 @@
             return await queryable.ProjectTo<TDestination>(config).DecompileAsync().SingleAsync();
         }
 
+        public static async Task<TDestination> ProjectToSingleAsync<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate, IConfigurationProvider config)
+        {
+            return await queryable.Where(predicate).ProjectTo<TDestination>(config).DecompileAsync().SingleAsync();
+        }
+
         public static async Task<TDestination> ProjectToSingleAsync<TDestination>(this IQueryable queryable)
         {
             return await queryable.ProjectTo<TDestination>().DecompileAsync().SingleAsync();
+        }
+
+        public static async Task<TDestination> ProjectToSingleAsync<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
+        {
+            return await queryable.Where(predicate).ProjectTo<TDestination>().DecompileAsync().SingleAsync();
         }
 
         public static async Task<TDestination> ProjectToFirstOrDefaultAsync<TDestination>(this IQueryable queryable, IConfigurationProvider config)
@@ -55,9 +77,19 @@
             return await queryable.ProjectTo<TDestination>(config).DecompileAsync().FirstOrDefaultAsync();
         }
 
+        public static async Task<TDestination> ProjectToFirstOrDefaultAsync<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate, IConfigurationProvider config)
+        {
+            return await queryable.Where(predicate).ProjectTo<TDestination>(config).DecompileAsync().FirstOrDefaultAsync();
+        }
+
         public static async Task<TDestination> ProjectToFirstOrDefaultAsync<TDestination>(this IQueryable queryable)
         {
             return await queryable.ProjectTo<TDestination>().DecompileAsync().FirstOrDefaultAsync();
+        }
+
+        public static async Task<TDestination> ProjectToFirstOrDefaultAsync<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
+        {
+            return await queryable.Where(predicate).ProjectTo<TDestination>().DecompileAsync().FirstOrDefaultAsync();
         }
 
         public static async Task<TDestination> ProjectToFirstAsync<TDestination>(this IQueryable queryable, IConfigurationProvider config)
@@ -65,9 +97,19 @@
             return await queryable.ProjectTo<TDestination>(config).DecompileAsync().FirstAsync();
         }
 
+        public static async Task<TDestination> ProjectToFirstAsync<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate, IConfigurationProvider config)
+        {
+            return await queryable.Where(predicate).ProjectTo<TDestination>(config).DecompileAsync().FirstAsync();
+        }
+
         public static async Task<TDestination> ProjectToFirstAsync<TDestination>(this IQueryable queryable)
         {
             return await queryable.ProjectTo<TDestination>().DecompileAsync().FirstAsync();
+        }
+
+        public static async Task<TDestination> ProjectToFirstAsync<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
+        {
+            return await queryable.Where(predicate).ProjectTo<TDestination>().DecompileAsync().FirstAsync();
         }
 
         public static List<TDestination> ProjectToList<TDestination>(this IQueryable queryable, IConfigurationProvider config)
@@ -95,9 +137,19 @@
             return queryable.ProjectTo<TDestination>(config).Decompile().SingleOrDefault();
         }
 
+        public static TDestination ProjectToSingleOrDefault<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate, IConfigurationProvider config)
+        {
+            return queryable.Where(predicate).ProjectTo<TDestination>(config).Decompile().SingleOrDefault();
+        }
+
         public static TDestination ProjectToSingleOrDefault<TDestination>(this IQueryable queryable)
         {
             return queryable.ProjectTo<TDestination>().Decompile().SingleOrDefault();
+        }
+
+        public static TDestination ProjectToSingleOrDefault<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
+        {
+            return queryable.Where(predicate).ProjectTo<TDestination>().Decompile().SingleOrDefault();
         }
 
         public static TDestination ProjectToSingle<TDestination>(this IQueryable queryable, IConfigurationProvider config)
@@ -105,9 +157,19 @@
             return queryable.ProjectTo<TDestination>(config).Decompile().Single();
         }
 
+        public static TDestination ProjectToSingle<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate, IConfigurationProvider config)
+        {
+            return queryable.Where(predicate).ProjectTo<TDestination>(config).Decompile().Single();
+        }
+
         public static TDestination ProjectToSingle<TDestination>(this IQueryable queryable)
         {
             return queryable.ProjectTo<TDestination>().Decompile().Single();
+        }
+
+        public static TDestination ProjectToSingle<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
+        {
+            return queryable.Where(predicate).ProjectTo<TDestination>().Decompile().Single();
         }
 
         public static TDestination ProjectToFirstOrDefault<TDestination>(this IQueryable queryable, IConfigurationProvider config)
@@ -115,9 +177,19 @@
             return queryable.ProjectTo<TDestination>(config).Decompile().FirstOrDefault();
         }
 
+        public static TDestination ProjectToFirstOrDefault<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate, IConfigurationProvider config)
+        {
+            return queryable.Where(predicate).ProjectTo<TDestination>(config).Decompile().FirstOrDefault();
+        }
+
         public static TDestination ProjectToFirstOrDefault<TDestination>(this IQueryable queryable)
         {
             return queryable.ProjectTo<TDestination>().Decompile().FirstOrDefault();
+        }
+
+        public static TDestination ProjectToFirstOrDefault<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
+        {
+            return queryable.Where(predicate).ProjectTo<TDestination>().Decompile().FirstOrDefault();
         }
 
         public static TDestination ProjectToFirst<TDestination>(this IQueryable queryable, IConfigurationProvider config)
@@ -125,9 +197,19 @@
             return queryable.ProjectTo<TDestination>(config).Decompile().First();
         }
 
+        public static TDestination ProjectToFirst<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate, IConfigurationProvider config)
+        {
+            return queryable.Where(predicate).ProjectTo<TDestination>(config).Decompile().First();
+        }
+
         public static TDestination ProjectToFirst<TDestination>(this IQueryable queryable)
         {
             return queryable.ProjectTo<TDestination>().Decompile().First();
+        }
+
+        public static TDestination ProjectToFirst<TSource, TDestination>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
+        {
+            return queryable.Where(predicate).ProjectTo<TDestination>().Decompile().First();
         }
 
         public static IQueryable<TDestination> ProjectToQueryable<TDestination>(this IQueryable queryable, IConfigurationProvider config)


### PR DESCRIPTION
Added some overloads to the extension methods to reduce call chaining when projections are needed, to more closely emulate what is possible with LINQ; for example this:

    queryable.Where(x => x.Id == 3).ProjectToSingle<Model>()

can be reduced to:

    queryable.ProjectToSingle<Model>(x => x.Id == 3)